### PR TITLE
fix docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
   
   yacf:
     restart: always
-    build: .
-    dockerfile: backend/Dockerfile
+    build: backend
     hostname: yacf.0x.codes
     ports:
       - "80:80"


### PR DESCRIPTION
I have this error:

```
➜ docker-compose up        
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services.yacf: 'dockerfile'
```
Anyway `Dockerfile` is the default name, only the build path need to be changed.